### PR TITLE
Update app.py

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,8 +68,8 @@ RUN poetry install --no-root
 # Copia o código do aplicativo
 COPY . /app
 
-# Exponha a porta 5000
-EXPOSE 5000
+# Exponha a porta 8080
+EXPOSE 8080
 
 # Comando para iniciar o script de inicialização
 CMD ["poetry", "run", "python", "app.py"]

--- a/app.py
+++ b/app.py
@@ -103,4 +103,4 @@ def passo3():
 
 if __name__ == "__main__":
     from waitress import serve
-    serve(app, host="0.0.0.0", port=int(os.environ.get("PORT", 5000)))
+    serve(app, host="0.0.0.0", port=int(os.environ.get("PORT", 8080)))


### PR DESCRIPTION
Após o deploy no ambiente da GCP essa mensagem surge na interface gráfica:

```
Revision 'mesageria-mvp-00009-7mz' is not ready and cannot serve traffic. The user-provided container failed to start and listen on the port defined provided by the PORT=8080 environment variable within the allocated timeout. This can happen when the container port is misconfigured or if the timeout is too short. The healtcheck timeout can be extended. Logs for this revision might contain more information. Logs URL: [Open Cloud Logging ](https://console.cloud.google.com/logs/viewer?project=predictive-keep-314223&resource=cloud_run_revision/service_name/mesageria-mvp/revision_name/mesageria-mvp-00009-7mz&advancedFilter=resource.type%3D%22cloud_run_revision%22%0Aresource.labels.service_name%3D%22mesageria-mvp%22%0Aresource.labels.revision_name%3D%22mesageria-mvp-00009-7mz%22)For more troubleshooting guidance, see https://cloud.google.com/run/docs/troubleshooting#container-failed-to-start
```

isso corre pois o docker precisa estar servindo uma API http na porta 8080 para que o Cloud Run identifique e gerencie as requisições. Esse PR corrige isso.